### PR TITLE
Matlab is mistaken as octave

### DIFF
--- a/autoload/matlab.vim
+++ b/autoload/matlab.vim
@@ -108,7 +108,7 @@ endfunction
 " Internal functions
 " ----------------------------------------------------------------------------
 function! matlab#_is_ml_script()
-  if &syntax ==? 'matlab'
+  if (&syntax ==? 'matlab' || &syntax ==? 'octave')
       return 1
   else
     echom 'Not a matlab script.'


### PR DESCRIPTION
Firstly, this is an absolutely amazing project and this simple thing has made working with Matlab so much more pleasurable. Thank you. 

However, I had to disable a few of my other plugins in order to get it working. Specifically, I think vim-polyglot mistakes .m files as 'octave' files instead of 'matlab' files (easy confusion). This causes &syntax to be 'octave' which fails the is_ml_script check.

While octave technically isn't Matlab, I'd argue that they are similar enough that any user who runs into this confusion likely knows what they are doing and that this will help prevent further confusion from other users. 
 